### PR TITLE
Add trap handler for Ctrl+C

### DIFF
--- a/bin/anyenv-update
+++ b/bin/anyenv-update
@@ -26,6 +26,13 @@ if [ "$1" = "--complete" ]; then
   exec anyenv-envs
 fi
 
+trap_handler() {
+  kill %1
+  exit 1
+}
+
+trap trap_handler SIGINT
+
 usage () {
   anyenv-help update 2>/dev/null
   [ -z "$1" ] || exit "$1"


### PR DESCRIPTION
Now, Ctrl+C works such as:

```bash
$ anyenv update rbenv --verbose
Updating 'rbenv'...
 |  cd ~/.anyenv/envs/rbenv
^C |  Failed to update. Use 'verbose' option for detailed, or 'force' option.
Updating 'rbenv/ruby-build'...
 |  cd ~/.anyenv/envs/rbenv/plugins/ruby-build
^C |  Failed to update. Use 'verbose' option for detailed, or 'force' option.
$
```

I fixed this action:

```bash
$ anyenv update rbenv --verbose
Updating 'rbenv'...
 |  cd ~/.anyenv/envs/rbenv
^C$
```
